### PR TITLE
Perfcollect automation

### DIFF
--- a/run-it.ps1
+++ b/run-it.ps1
@@ -1,14 +1,15 @@
 #!/usr/bin/env pwsh
 
 param(
-    [string] $app,
+    [string] $appname,
     [string] $url,
     [switch] $trim,
     [switch] $trimr2r,
     [switch] $aggro,
     [switch] $r2r,
     [switch] $singleFile,
-    [switch] $time)
+    [switch] $time,
+    [string] $trace)
 
 dotnet clean
 
@@ -30,20 +31,38 @@ elseif ($IsLinux)
 {
     $rid = "linux-x64"
 }
-$path = Join-Path "bin" "Release" "netcoreapp3.0" "$rid" "publish"
-if (Test-Path $path)
+
+if ($trace)
 {
-    Write-Debug "Deleting $path"
-    Remove-Item $path -r -for
+    if (-not $IsLinux)
+    {
+        Write-Error "tracing is only supported on linux"
+        exit
+    }
+    if (Test-Path "$trace.trace.zip")
+    {
+        Write-Error "$trace.trace.zip already exists"
+        exit
+    }
 }
 
-dotnet publish -c Release -r $rid /p:PublishTrimmed=$trim /p:LinkAggressively=$aggro /p:LinkAwayReadyToRun=$trimr2r /p:PublishReadyToRun=$r2r /p:PublishSingleFile=$singleFile /bl
+$publish_dir = Join-Path "bin" "Release" "netcoreapp3.0" "$rid" "publish"
+if (Test-Path $publish_dir)
+{
+    Write-Debug "Deleting $publish_dir"
+    Remove-Item $publish_dir -r -for
+}
 
-Push-Location $path
+& dotnet publish -c Release -r $rid /p:PublishTrimmed=$trim /p:LinkAggressively=$aggro /p:LinkAwayReadyToRun=$trimr2r /p:PublishReadyToRun=$r2r /p:PublishSingleFile=$singleFile /bl
+
 Write-Host ("Size is {0:N2} MB" -f ((Get-ChildItem . -Recurse | Measure-Object -Property Length -Sum -ErrorAction Stop).Sum / 1MB))
 
-$app_path = Join-Path (Get-Location) $app
-if (-not (Test-Path $app_path))
+$app_path = Join-Path "$publish_dir" "$appname"
+if ($IsWindows)
+{
+    $app_path = "$app_path" + ".exe"
+}
+if (-not (Test-Path "$app_path"))
 {
     Write-Error "app not found at $app_path"
     exit
@@ -52,6 +71,66 @@ $app_args = @()
 $console = $url -eq $null -or $url -eq ""
 
 $iterations = 10
+
+if ($trace)
+{
+    # 1. get perfcollect
+
+    $perfcollect = Join-Path "$PSScriptRoot" "perfcollect"
+    if (-not (Test-Path "$perfcollect"))
+    {
+        & wget "http://aka.ms/perfcollect" -O "$perfcollect"
+        & chmod +x "$perfcollect"
+    }
+
+    # 2. copy crossgen to the publish directory (used to resolve R2R symbols)
+
+    $deps_json = Join-Path "$publish_dir" "$appname.deps.json"
+    if (-not (Test-Path $deps_json))
+    {
+        Write-Error "deps.json not found at $deps_json"
+        exit
+    }
+    $runtimeversion = Select-String -Path "$deps_json" -Pattern "runtimepack.Microsoft.NETCore.App.Runtime.$rid" `
+      | Select-Object -First 1 | %{ $_ -split ':' } | Select-Object -Last 1 | %{ $_ -split '"' } | Select-Object -Index 1
+    if (-not ($runtimeversion -and ($runtimeversion.StartsWith("3.0.0"))))
+    {
+        Write-Error "unable to get runtime version"
+        exit
+    }
+    $crossgen = Join-Path "$env:HOME" ".nuget" "packages" "microsoft.netcore.app.runtime.linux-x64" "$runtimeversion" "tools" "crossgen"
+    if (-not (Test-Path "$crossgen"))
+    {
+        Write-Error "crossgen does not exist at `"$crossgen`""
+        exit
+    }
+    Copy-Item "$crossgen" "$publish_dir"
+
+    # 3. install native symbols for the runtime libraries
+
+    & dotnet tool install -g dotnet-symbol
+    $env:DOTNET_ROOT = (Split-Path -Parent (Get-Command dotnet).Source)
+    $dotnet_symbol = Join-Path "$env:HOME" ".dotnet" "tools" "dotnet-symbol"
+    if (-not (Test-Path "$dotnet_symbol"))
+    {
+        Write-Error "dotnet-symbol not found at $dotnet_symbol"
+        exit
+    }
+    & "$dotnet_symbol" --symbols "$publish_dir/lib*.so"
+
+    # 4. run perfcollect and hold onto the perfcollect PID to wait on it later
+
+    $pid_file = & mktemp -u
+    & mkfifo "$pid_file"
+    Start-Process sudo -ArgumentList @("sh", "-c", "`"echo `$`$ > `"$pid_file`"; exec $perfcollect collect $trace`"")
+    $perfcollect_pid = & cat "$pid_file"
+    Write-Host "perfcollect PID: $perfcollect_pid"
+
+    # 5. set COMPlus variables for tracing
+
+    $env:COMPlus_PerfMapEnabled = 1
+    $env:COMPlus_EnableEventLog = 1
+}
 
 if ($time)
 {
@@ -73,7 +152,7 @@ if ($time)
         }
     }
 
-    $avg = $sum / 10
+    $avg = $sum / $iterations
     Write-Host "Average startup time (ms): $avg"
 
     if (-not $console) {
@@ -96,5 +175,3 @@ else
 {
     dotnet $app
 }
-
-Pop-Location

--- a/run-it.ps1
+++ b/run-it.ps1
@@ -175,3 +175,9 @@ else
 {
     dotnet $app
 }
+
+if ($trace)
+{
+    & sudo kill ((Get-Process -Name 'perf').Id)
+    Wait-Process -Id "$perfcollect_pid"
+}

--- a/run-it.ps1
+++ b/run-it.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+
 param(
     [string] $app,
     [string] $url,
@@ -10,37 +12,56 @@ param(
 
 dotnet clean
 
-if (Test-Path "obj\")
+if (Test-Path "obj")
 {
     Write-Debug "Deleting obj"
-    Remove-Item "obj\" -r -for
-}    
+    Remove-Item "obj" -r -for
+}
 
-$path = "bin\Release\netcoreapp3.0\win10-x64\publish\"
+if ($IsWindows)
+{
+    $rid = "win10-x64"
+}
+elseif ($IsMacOS)
+{
+    $rid = "osx-x64"
+}
+elseif ($IsLinux)
+{
+    $rid = "linux-x64"
+}
+$path = Join-Path "bin" "Release" "netcoreapp3.0" "$rid" "publish"
 if (Test-Path $path)
 {
     Write-Debug "Deleting $path"
     Remove-Item $path -r -for
 }
 
-dotnet publish -c Release -r win10-x64 /p:PublishTrimmed=$trim /p:LinkAggressively=$aggro /p:LinkAwayReadyToRun=$trimr2r /p:PublishReadyToRun=$r2r /p:PublishSingleFile=$singleFile /bl
+dotnet publish -c Release -r $rid /p:PublishTrimmed=$trim /p:LinkAggressively=$aggro /p:LinkAwayReadyToRun=$trimr2r /p:PublishReadyToRun=$r2r /p:PublishSingleFile=$singleFile /bl
 
 Push-Location $path
 Write-Host ("Size is {0:N2} MB" -f ((Get-ChildItem . -Recurse | Measure-Object -Property Length -Sum -ErrorAction Stop).Sum / 1MB))
 
-$app_path = '.\' + $app
+$app_path = Join-Path (Get-Location) $app
+if (-not (Test-Path $app_path))
+{
+    Write-Error "app not found at $app_path"
+    exit
+}
 $app_args = @()
 $console = $url -eq $null -or $url -eq ""
+
+$iterations = 10
 
 if ($time)
 {
     $app_args += ("--time")
 
     $sum = 0
-    for ($i = 0; $i -lt 11; $i++)
+    for ($i = 0; $i -lt ($iterations + 1); $i++)
     {
-        Write-Debug "Starting $app"     
-        $result = Measure-Command {    
+        Write-Debug "Starting $app"
+        $result = Measure-Command {
             $proc = Start-Process -FilePath $app_path -ArgumentList $app_args -PassThru -NoNewWindow -RedirectStandardOutput '.\NUL'
             $proc.WaitForExit()
         }

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,12 @@
+#!/bin/env pwsh
+
+# This is the script that we are using to collect size/startup numbers
+# for the small/fast/single exe prototype.
+
+$app = "ApiTemplate"
+$url = "http://localhost:5000/WeatherForecast"
+$trace_name = Join-Path "$PSScriptRoot" "$app"
+
+Push-Location (Join-Path "$PSScriptRoot" "src" "$app")
+& (Join-Path "$PSScriptRoot" "run-it.ps1") -appname "$app" -url "$url" -trimr2r -aggro -trim -time -trace "$trace_name"
+Pop-Location

--- a/src/ApiTemplate/Program.cs
+++ b/src/ApiTemplate/Program.cs
@@ -23,7 +23,7 @@ namespace ApiTemplate
             using (var host = CreateHostBuilder(args).Start())
             {
                 var client = new HttpClient();
-                var response = await client.GetAsync("https://localhost:5001/WeatherForecast");
+                var response = await client.GetAsync("http://localhost:5000/WeatherForecast");
                 response.EnsureSuccessStatusCode();
                 Console.WriteLine("Completed At: ", DateTime.Now.Ticks);
             }

--- a/src/ApiTemplate/Startup.cs
+++ b/src/ApiTemplate/Startup.cs
@@ -36,8 +36,6 @@ namespace ApiTemplate
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseHttpsRedirection();
-
             app.UseRouting();
 
             app.UseAuthorization();


### PR DESCRIPTION
This makes the script run cross-plat, and adds perfcollect automation for linux.
The arguments now take a "-trace <string>" argument with the name of the trace to output.
The -app (renamed to -appname) now expects the name of the app, without extension, making it more xplat friendly.

@rynowak PTAL