### PR TITLE
Fix path

### DIFF
--- a/src/CustomLinkerSteps.targets
+++ b/src/CustomLinkerSteps.targets
@@ -6,8 +6,8 @@
 
   <ItemGroup Condition="'$(UseCustomStepPreserveDI)' == 'true'">
     <ILLinkCustomStep Include="CustomSteps.PreserveDIStep, CustomSteps, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <AssemblyPath>$(MSBuildThisFileDirectory)CustomSteps\bin\$(Configuration)\netcoreapp2.0\linux-x64\CustomSteps.dll</AssemblyPath>
-      <PdbPath>$(MSBuildThisFileDirectory)CustomSteps\bin\$(Configuration)\netcoreapp2.0\linux-x64\CustomSteps.pdb</PdbPath>
+      <AssemblyPath>$(MSBuildThisFileDirectory)CustomSteps\bin\$(Configuration)\netcoreapp2.0\$(RuntimeIdentifier)\CustomSteps.dll</AssemblyPath>
+      <PdbPath>$(MSBuildThisFileDirectory)CustomSteps\bin\$(Configuration)\netcoreapp2.0\$(RuntimeIdentifier)\CustomSteps.pdb</PdbPath>
       <BeforeStep>MarkStep</BeforeStep>
     </ILLinkCustomStep>
   </ItemGroup>


### PR DESCRIPTION
This fixes the publishing step:
```
andrewau@andrewau-ubuntu:~/git/link-a-thon$ dotnet publish -c Release -r linux-x64 /p:PublishTrimmed=true /p:LinkAggressively=true /p:UsePublishFilterList=true /p:PublishReadyToRun=true /p:UseStaticHost=true /p:SelfContained=true src/ApiTemplate/ApiTemplate.csproj -o publish
Microsoft (R) Build Engine version 16.3.0-preview-19377-01+dd8019d9e for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.
 
/home/andrewau/dotnet/sdk/3.0.100-preview8-013656/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ILLink.targets(14,3): warning MSB4011: "/home/andrewau/dotnet/sdk/3.0.100-preview8-013656/Sdks/ILLink.Tasks/Sdk/Sdk.props" cannot be imported again. It was already imported at "/home/andrewau/git/link-a-thon/src/CustomSteps/CustomSteps.csproj (3,3)". This is most likely a build authoring error. This subsequent import will be ignored. 
  Restore completed in 148.22 ms for /home/andrewau/git/link-a-thon/src/ApiTemplate/ApiTemplate.csproj.
  Restore completed in 3.82 sec for /home/andrewau/git/link-a-thon/src/CustomSteps/CustomSteps.csproj.
  You are using a preview version of .NET Core. See: https://aka.ms/dotnet-core-preview
/home/andrewau/dotnet/sdk/3.0.100-preview8-013656/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ILLink.targets(14,3): warning MSB4011: "/home/andrewau/dotnet/sdk/3.0.100-preview8-013656/Sdks/ILLink.Tasks/Sdk/Sdk.props" cannot be imported again. It was already imported at "/home/andrewau/git/link-a-thon/src/CustomSteps/CustomSteps.csproj (3,3)". This is most likely a build authoring error. This subsequent import will be ignored. 
/home/andrewau/dotnet/sdk/3.0.100-preview8-013656/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ILLink.targets(14,3): warning MSB4011: "/home/andrewau/dotnet/sdk/3.0.100-preview8-013656/Sdks/ILLink.Tasks/Sdk/Sdk.props" cannot be imported again. It was already imported at "/home/andrewau/git/link-a-thon/src/CustomSteps/CustomSteps.csproj (3,3)". This is most likely a build authoring error. This subsequent import will be ignored. 
  CustomSteps -> /home/andrewau/git/link-a-thon/src/CustomSteps/bin/Release/netcoreapp2.0/linux-x64/CustomSteps.dll
/home/andrewau/git/link-a-thon/src/CustomLinkerSteps.targets(27,5): error MSB3030: Could not copy the file "/home/andrewau/git/link-a-thon/src/CustomSteps/bin/Release/netcoreapp2.0/CustomSteps.dll" because it was not found. [/home/andrewau/git/link-a-thon/src/ApiTemplate/ApiTemplate.csproj]
/home/andrewau/git/link-a-thon/src/CustomLinkerSteps.targets(27,5): error MSB3030: Could not copy the file "/home/andrewau/git/link-a-thon/src/CustomSteps/bin/Release/netcoreapp2.0/CustomSteps.pdb" because it was not found. [/home/andrewau/git/link-a-thon/src/ApiTemplate/ApiTemplate.csproj]
andrewau@andrewau-ubuntu:~/git/link-a-thon$ 
```
