### PR TITLE
Add gRPC service

### DIFF
--- a/link-a-thon.sln
+++ b/link-a-thon.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlatformJson", "src\Platfor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlatformTcpListener", "src\PlatformTcpListener\PlatformTcpListener.csproj", "{3A087CEB-1C0C-42B0-AA54-0557D488A119}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GrpcService", "src\GrpcService\GrpcService.csproj", "{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -131,6 +133,18 @@ Global
 		{3A087CEB-1C0C-42B0-AA54-0557D488A119}.Release|x64.Build.0 = Release|Any CPU
 		{3A087CEB-1C0C-42B0-AA54-0557D488A119}.Release|x86.ActiveCfg = Release|Any CPU
 		{3A087CEB-1C0C-42B0-AA54-0557D488A119}.Release|x86.Build.0 = Release|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Debug|x64.Build.0 = Debug|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Debug|x86.Build.0 = Debug|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Release|x64.ActiveCfg = Release|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Release|x64.Build.0 = Release|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Release|x86.ActiveCfg = Release|Any CPU
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -144,6 +158,7 @@ Global
 		{3D8F01BC-4F05-4DDD-BAAC-353E1F7F4ED8} = {0E746D10-DD4B-4230-A958-6DBC5F3CAE98}
 		{208A5E18-1F3D-4400-AFD6-71BB1A97DCDC} = {DC51A226-BB52-4111-BCC5-5FA4281F458A}
 		{3A087CEB-1C0C-42B0-AA54-0557D488A119} = {DC51A226-BB52-4111-BCC5-5FA4281F458A}
+		{BB1A2B48-4F62-483F-B6DE-D9BDDD3439B4} = {DC51A226-BB52-4111-BCC5-5FA4281F458A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7BEDCD2-0042-4CFF-AC55-3ED3608E2C19}

--- a/src/GrpcService/GrpcService.csproj
+++ b/src/GrpcService/GrpcService.csproj
@@ -1,0 +1,26 @@
+﻿<Project>
+
+  <!-- Don't simplify this. We need to override stuff defined in the SDK. -->
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.Web" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <UseCustomStepPreserveDI>true</UseCustomStepPreserveDI>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\benchmark_service.proto" GrpcServices="Both" />
+    <Protobuf Include="Protos\messages.proto" GrpcServices="Both" />
+
+    <PackageReference Include="Grpc.AspNetCore" Version="2.23.2" />
+
+    <!-- Can describe roots to the linker -->
+    <TrimmerRootDescriptor Include="Linker.xml" Condition="'$(LinkAggressively)' == 'true'" />
+  </ItemGroup>
+
+  <!-- Don't simplify this. We need to override stuff defined in the SDK. -->
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk.Web" />
+  <Import Project="$(CustomLinkerStepsTargetsPath)" />
+  <Import Project="$(CustomR2RLogicTargetsPath)" Condition="'$([MSBuild]::IsOSPlatform(Windows))' != 'true'" />
+
+</Project>

--- a/src/GrpcService/Linker.xml
+++ b/src/GrpcService/Linker.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- See: https://github.com/mono/linker/blob/master/src/linker/README.md#syntax-of-xml-descriptor -->
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.Object" />
+  </assembly>
+
+  <assembly fullname="GrpcService">
+    <type fullname="GrpcService.Startup" />
+    <type fullname="BenchmarkServiceImpl" />
+  </assembly>
+
+  <assembly fullname="Microsoft.AspNetCore.Routing">
+    <type fullname="Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware">
+      <method name="Invoke" />
+      <method name="InvokeAsync" />
+      <method name=".ctor" />
+    </type>
+    <type fullname="Microsoft.AspNetCore.Routing.EndpointMiddleware">
+      <method name="Invoke" />
+      <method name="InvokeAsync" />
+      <method name=".ctor" />
+    </type>
+  </assembly>
+
+  <assembly fullname="Microsoft.AspNetCore.Authorization.Policy">
+    <type fullname="Microsoft.AspNetCore.Authorization.AuthorizationMiddleware">
+      <method name="Invoke" />
+      <method name="InvokeAsync" />
+      <method name=".ctor" />
+    </type>
+  </assembly>
+
+  <assembly fullname="Microsoft.AspNetCore.HttpsPolicy">
+    <type fullname="Microsoft.AspNetCore.HttpsPolicy.HttpsRedirectionMiddleware">
+      <method name="Invoke" />
+      <method name="InvokeAsync" />
+      <method name=".ctor" />
+    </type>
+  </assembly>
+
+  <assembly fullname="Microsoft.AspNetCore.HostFiltering">
+    <type fullname="Microsoft.AspNetCore.HostFiltering.HostFilteringMiddleware">
+      <method name="Invoke" />
+      <method name="InvokeAsync" />
+      <method name=".ctor" />
+    </type>
+  </assembly>
+
+</linker>

--- a/src/GrpcService/Program.cs
+++ b/src/GrpcService/Program.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+#if TIME
+using System.Diagnostics;
+using Grpc.Net.Client;
+using Grpc.Testing;
+using Google.Protobuf;
+#endif
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+
+namespace GrpcService
+{
+    public class Program
+    {
+#if TIME
+        public static async Task Main(string[] args)
+        {
+            // For local measurements, use a stopwatch and make a
+            // request from the app itself to get an approximate
+            // measurement.
+            if (args.Contains("--time"))
+            {
+                Stopwatch stopWatch = new Stopwatch();
+                stopWatch.Start();
+                using (var host = CreateHostBuilder(args).Start())
+                {
+                    AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+                    var channel = GrpcChannel.ForAddress("http://localhost:5000");
+                    var client = new BenchmarkService.BenchmarkServiceClient(channel);
+
+                    var request = new SimpleRequest
+                    {
+                        Payload = new Payload { Body = ByteString.CopyFrom(new byte[0]) },
+                        ResponseSize = 0
+                    };
+                    _ = await client.UnaryCallAsync(request);
+                    stopWatch.Stop();
+                    TimeSpan ts = stopWatch.Elapsed;
+                    Console.WriteLine("Stopwatch startup measurement: " + ts.Milliseconds);
+                }
+                return;
+            }
+            else
+            {
+                var host = CreateHostBuilder(args).Build();
+
+                host.Run();
+            }
+        }
+#else
+        public static void Main(string[] args)
+        {
+            // The more accurate numbers are measured using the aspnet
+            // benchmarking infrastructure to make requests from
+            // another server.
+            var host = CreateHostBuilder(args).Build();
+
+            host.Run();
+        }
+#endif
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.ConfigureKestrel(kestrelOptions =>
+                    {
+                        kestrelOptions.ConfigureEndpointDefaults(listenOptions =>
+                        {
+                            listenOptions.Protocols = HttpProtocols.Http2;
+                        });
+                    });
+                    webBuilder.UseUrls("http://*:5000");
+                    webBuilder.UseStartup<Startup>();
+                })
+                .ConfigureLogging(loggingBuilder =>
+                                  // Don't perturb the measurement with log spew for every request
+                                  // Do this in code to avoid shipping a settings file for the single executable
+                                  loggingBuilder.SetMinimumLevel(LogLevel.Error)
+                                                // But keep logging for app startup/shutdown
+                                                .AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Information));
+    }
+}

--- a/src/GrpcService/Protos/benchmark_service.proto
+++ b/src/GrpcService/Protos/benchmark_service.proto
@@ -1,0 +1,44 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An integration test service that covers all the method signature permutations
+// of unary/streaming requests/responses.
+syntax = "proto3";
+
+import "Protos/messages.proto";
+
+package grpc.testing;
+
+service BenchmarkService {
+  // One request followed by one response.
+  // The server returns the client payload as-is.
+  rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
+
+  // Repeated sequence of one request followed by one response.
+  // Should be called streaming ping-pong
+  // The server returns the client payload as-is on each response
+  rpc StreamingCall(stream SimpleRequest) returns (stream SimpleResponse);
+
+  // Single-sided unbounded streaming from client to server
+  // The server returns the client payload as-is once the client does WritesDone
+  rpc StreamingFromClient(stream SimpleRequest) returns (SimpleResponse);
+
+  // Single-sided unbounded streaming from server to client
+  // The server repeatedly returns the client payload as-is
+  rpc StreamingFromServer(SimpleRequest) returns (stream SimpleResponse);
+
+  // Two-sided unbounded streaming between server to client
+  // Both sides send the content of their own choice to the other
+  rpc StreamingBothWays(stream SimpleRequest) returns (stream SimpleResponse);
+}

--- a/src/GrpcService/Protos/messages.proto
+++ b/src/GrpcService/Protos/messages.proto
@@ -1,0 +1,192 @@
+
+// Copyright 2015-2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Message definitions to be used by integration test service definitions.
+
+syntax = "proto3";
+
+package grpc.testing;
+
+// TODO(dgq): Go back to using well-known types once
+// https://github.com/grpc/grpc/issues/6980 has been fixed.
+// import "google/protobuf/wrappers.proto";
+message BoolValue {
+  // The bool value.
+  bool value = 1;
+}
+
+// The type of payload that should be returned.
+enum PayloadType {
+  // Compressable text format.
+  COMPRESSABLE = 0;
+}
+
+// A block of data, to simply increase gRPC message size.
+message Payload {
+  // The type of data in body.
+  PayloadType type = 1;
+  // Primary contents of payload.
+  bytes body = 2;
+}
+
+// A protobuf representation for grpc status. This is used by test
+// clients to specify a status that the server should attempt to return.
+message EchoStatus {
+  int32 code = 1;
+  string message = 2;
+}
+
+// The type of route that a client took to reach a server w.r.t. gRPCLB.
+// The server must fill in "fallback" if it detects that the RPC reached
+// the server via the "gRPCLB fallback" path, and "backend" if it detects
+// that the RPC reached the server via "gRPCLB backend" path (i.e. if it got
+// the address of this server from the gRPCLB server BalanceLoad RPC). Exactly
+// how this detection is done is context and server dependant.
+enum GrpclbRouteType {
+  // Server didn't detect the route that a client took to reach it.
+  GRPCLB_ROUTE_TYPE_UNKNOWN = 0;
+  // Indicates that a client reached a server via gRPCLB fallback.
+  GRPCLB_ROUTE_TYPE_FALLBACK = 1;
+  // Indicates that a client reached a server as a gRPCLB-given backend.
+  GRPCLB_ROUTE_TYPE_BACKEND = 2;
+}
+
+// Unary request.
+message SimpleRequest {
+  // Desired payload type in the response from the server.
+  // If response_type is RANDOM, server randomly chooses one from other formats.
+  PayloadType response_type = 1;
+
+  // Desired payload size in the response from the server.
+  int32 response_size = 2;
+
+  // Optional input payload sent along with the request.
+  Payload payload = 3;
+
+  // Whether SimpleResponse should include username.
+  bool fill_username = 4;
+
+  // Whether SimpleResponse should include OAuth scope.
+  bool fill_oauth_scope = 5;
+
+  // Whether to request the server to compress the response. This field is
+  // "nullable" in order to interoperate seamlessly with clients not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the response's compression status.
+  BoolValue response_compressed = 6;
+
+  // Whether server should return a given status
+  EchoStatus response_status = 7;
+
+  // Whether the server should expect this request to be compressed.
+  BoolValue expect_compressed = 8;
+
+  // Whether SimpleResponse should include server_id.
+  bool fill_server_id = 9;
+
+  // Whether SimpleResponse should include grpclb_route_type.
+  bool fill_grpclb_route_type = 10;
+}
+
+// Unary response, as configured by the request.
+message SimpleResponse {
+  // Payload to increase message size.
+  Payload payload = 1;
+  // The user the request came from, for verifying authentication was
+  // successful when the client expected it.
+  string username = 2;
+  // OAuth scope.
+  string oauth_scope = 3;
+
+  // Server ID. This must be unique among different server instances,
+  // but the same across all RPC's made to a particular server instance.
+  string server_id = 4;
+  // gRPCLB Path.
+  GrpclbRouteType grpclb_route_type = 5;
+}
+
+// Client-streaming request.
+message StreamingInputCallRequest {
+  // Optional input payload sent along with the request.
+  Payload payload = 1;
+
+  // Whether the server should expect this request to be compressed. This field
+  // is "nullable" in order to interoperate seamlessly with servers not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the request's compression status.
+  BoolValue expect_compressed = 2;
+
+  // Not expecting any payload from the response.
+}
+
+// Client-streaming response.
+message StreamingInputCallResponse {
+  // Aggregated size of payloads received from the client.
+  int32 aggregated_payload_size = 1;
+}
+
+// Configuration for a particular response.
+message ResponseParameters {
+  // Desired payload sizes in responses from the server.
+  int32 size = 1;
+
+  // Desired interval between consecutive responses in the response stream in
+  // microseconds.
+  int32 interval_us = 2;
+
+  // Whether to request the server to compress the response. This field is
+  // "nullable" in order to interoperate seamlessly with clients not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the response's compression status.
+  BoolValue compressed = 3;
+}
+
+// Server-streaming request.
+message StreamingOutputCallRequest {
+  // Desired payload type in the response from the server.
+  // If response_type is RANDOM, the payload from each response in the stream
+  // might be of different types. This is to simulate a mixed type of payload
+  // stream.
+  PayloadType response_type = 1;
+
+  // Configuration for each expected response message.
+  repeated ResponseParameters response_parameters = 2;
+
+  // Optional input payload sent along with the request.
+  Payload payload = 3;
+
+  // Whether server should return a given status
+  EchoStatus response_status = 7;
+}
+
+// Server-streaming response, as configured by the request and parameters.
+message StreamingOutputCallResponse {
+  // Payload to increase response size.
+  Payload payload = 1;
+}
+
+// For reconnect interop test only.
+// Client tells server what reconnection parameters it used.
+message ReconnectParams {
+  int32 max_reconnect_backoff_ms = 1;
+}
+
+// For reconnect interop test only.
+// Server tells client whether its reconnects are following the spec and the
+// reconnect backoffs it saw.
+message ReconnectInfo {
+  bool passed = 1;
+  repeated int32 backoff_ms = 2;
+}

--- a/src/GrpcService/Services/BenchmarkServiceImpl.cs
+++ b/src/GrpcService/Services/BenchmarkServiceImpl.cs
@@ -1,0 +1,80 @@
+﻿using System.Threading.Tasks;
+using Grpc.Testing;
+using Grpc.Core;
+using Google.Protobuf;
+using System;
+
+class BenchmarkServiceImpl : BenchmarkService.BenchmarkServiceBase
+{
+    public override Task<SimpleResponse> UnaryCall(SimpleRequest request, ServerCallContext context)
+    {
+        return Task.FromResult(CreateResponse(request));
+    }
+
+    public override async Task StreamingCall(IAsyncStreamReader<SimpleRequest> requestStream, IServerStreamWriter<SimpleResponse> responseStream, ServerCallContext context)
+    {
+        await foreach (var item in requestStream.ReadAllAsync())
+        {
+            await responseStream.WriteAsync(CreateResponse(item));
+        }
+    }
+
+    public override async Task StreamingFromServer(SimpleRequest request, IServerStreamWriter<SimpleResponse> responseStream, ServerCallContext context)
+    {
+        while (!context.CancellationToken.IsCancellationRequested)
+        {
+            await responseStream.WriteAsync(CreateResponse(request));
+        }
+    }
+
+    public override async Task<SimpleResponse> StreamingFromClient(IAsyncStreamReader<SimpleRequest> requestStream, ServerCallContext context)
+    {
+        SimpleRequest lastRequest = null;
+        await foreach (var item in requestStream.ReadAllAsync())
+        {
+            lastRequest = item;
+        };
+
+        if (lastRequest == null)
+        {
+            throw new InvalidOperationException("No client requests received.");
+        }
+
+        return CreateResponse(lastRequest);
+    }
+
+    public override async Task StreamingBothWays(IAsyncStreamReader<SimpleRequest> requestStream, IServerStreamWriter<SimpleResponse> responseStream, ServerCallContext context)
+    {
+        var messageData = ByteString.CopyFrom(new byte[100]);
+        var clientComplete = false;
+
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var message in requestStream.ReadAllAsync())
+            {
+                // Nom nom nom
+            }
+
+            clientComplete = true;
+        });
+
+        // Write outgoing messages until client is complete
+        while (!clientComplete)
+        {
+            await responseStream.WriteAsync(new SimpleResponse
+            {
+                Payload = new Payload { Body = messageData }
+            });
+        }
+
+        await readTask;
+    }
+
+    public static SimpleResponse CreateResponse(SimpleRequest request)
+    {
+        var body = ByteString.CopyFrom(new byte[request.ResponseSize]);
+
+        var payload = new Payload { Body = body };
+        return new SimpleResponse { Payload = payload };
+    }
+}

--- a/src/GrpcService/Startup.cs
+++ b/src/GrpcService/Startup.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace GrpcService
+{
+#if !CUSTOM_BUILDER
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddGrpc();
+            services.AddAuthorization();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGrpcService<BenchmarkServiceImpl>();
+            });
+        }
+    }
+#endif
+}

--- a/src/GrpcService/appsettings.Development.json
+++ b/src/GrpcService/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/src/GrpcService/appsettings.json
+++ b/src/GrpcService/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Add gRPC service. Uses the benchmarking proto so the existing `GrpcWorker` in aspnet/benchmarks will be able to call it.

I haven't updated Linker.xml or tested linking/trimming. We can do some pair programming to get that piece working.